### PR TITLE
Add a tox env and github action to automate the testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+name: Test epydoc
+
+on:
+  push:
+    branches: "*"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+
+    - name: Install tox
+      run: |
+        python -m pip install --upgrade pip tox
+
+    - name: Install epydoc
+      run: |
+        cd src
+        python setup.py install
+        cd ..
+
+    - name: Log system information
+      run: |
+        test -r /etc/os-release && sh -c '. /etc/os-release && echo "OS: $PRETTY_NAME"'
+        python --version
+        python -c "print('\nENVIRONMENT VARIABLES\n=====================\n')"
+        python -c "import os; [print(f'{k}={v}') for k, v in os.environ.items()]"
+    
+    - name: Test with python2.7 and python3.8
+      run: |
+        cd src
+        tox 
+        cd ..
+        

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+minversion=3.20.1
+requires=
+    virtualenv>=20.0.35
+envlist =
+    test-{py27,py38}
+
+[testenv]
+deps =
+    test: docutils
+
+commands =
+    test-py27: python epydoc/test/__init__.py
+    test-py38: python3 epydoc/test/__init__.py
+


### PR DESCRIPTION
This PR include a very minimal tox env with a workflow to run tests on python2.7 and python3.8.
There are a few failures when running python3.8.

I'm interested into this project because I think we could port over / merge some features to pydoctor, the actual replacement for epydoc :)